### PR TITLE
MM-19864 Implement Scoping Element for AD/LDAP

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -1,6 +1,6 @@
 package saml2
 
-import "github.com/russellhaering/gosaml2/types"
+import "github.com/mattermost/gosaml2/types"
 
 // Values is a convenience wrapper for a map of strings to Attributes, which
 // can be used for easy access to the string values of Attribute lists.

--- a/build_request.go
+++ b/build_request.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 
 	"github.com/beevik/etree"
-	"github.com/russellhaering/gosaml2/uuid"
+	"github.com/mattermost/gosaml2/uuid"
 )
 
 const issueInstantFormat = "2006-01-02T15:04:05Z"
@@ -53,6 +53,14 @@ func (sp *SAMLServiceProvider) buildAuthnRequest(includeSig bool) (*etree.Docume
 			authnContextClassRef := requestedAuthnContext.CreateElement("saml:AuthnContextClassRef")
 			authnContextClassRef.SetText(context)
 		}
+	}
+
+	if sp.ScopingIDPProviderId != "" && sp.ScopingIDPProviderName != "" {
+		scoping := authnRequest.CreateElement("samlp:Scoping")
+		idpList := scoping.CreateElement("samlp:IDPList")
+		idpEntry := idpList.CreateElement("samlp:IDPEntry")
+		idpEntry.CreateAttr("ProviderID", sp.ScopingIDPProviderId)
+		idpEntry.CreateAttr("Name", sp.ScopingIDPProviderName)
 	}
 
 	doc := etree.NewDocument()

--- a/build_request_test.go
+++ b/build_request_test.go
@@ -115,3 +115,28 @@ func TestRequestedAuthnContextIncluded(t *testing.T) {
 	require.Equal(t, el.Tag, "AuthnContextClassRef")
 	require.Equal(t, el.Text(), AuthnContextPasswordProtectedTransport)
 }
+
+func TestScopingIDProviderIncluded(t *testing.T) {
+	spURL := "https://sp.test"
+	sp := SAMLServiceProvider{
+		AssertionConsumerServiceURL: spURL,
+		AudienceURI:                 spURL,
+		IdentityProviderIssuer:      spURL,
+		IdentityProviderSSOURL:      "https://idp.test/saml/sso",
+		SignAuthnRequests:           false,
+		ScopingIDPProviderId:        "providerID",
+		ScopingIDPProviderName:      "providerName",
+	}
+
+	request, err := sp.BuildAuthRequest()
+	require.NoError(t, err)
+
+	doc := etree.NewDocument()
+	err = doc.ReadFromString(request)
+	require.NoError(t, err)
+
+	idpEntry := doc.FindElement("./AuthnRequest/Scoping/IDPList/IDPEntry")
+
+	require.Equal(t, idpEntry.SelectAttrValue("ProviderID", ""), "providerID")
+	require.Equal(t, idpEntry.SelectAttrValue("Name", ""), "providerName")
+}

--- a/decode_response.go
+++ b/decode_response.go
@@ -12,7 +12,7 @@ import (
 	"encoding/xml"
 
 	"github.com/beevik/etree"
-	"github.com/russellhaering/gosaml2/types"
+	"github.com/mattermost/gosaml2/types"
 	dsig "github.com/russellhaering/goxmldsig"
 	"github.com/russellhaering/goxmldsig/etreeutils"
 )

--- a/providertests/exercise.go
+++ b/providertests/exercise.go
@@ -5,7 +5,7 @@ package providertests
 import (
 	"testing"
 
-	saml2 "github.com/russellhaering/gosaml2"
+	saml2 "github.com/mattermost/gosaml2"
 	"github.com/stretchr/testify/require"
 )
 

--- a/providertests/exercise_go_1_6.go
+++ b/providertests/exercise_go_1_6.go
@@ -5,7 +5,7 @@ package providertests
 import (
 	"testing"
 
-	saml2 "github.com/russellhaering/gosaml2"
+	saml2 "github.com/mattermost/gosaml2"
 	"github.com/stretchr/testify/require"
 )
 

--- a/providertests/oktadev_test.go
+++ b/providertests/oktadev_test.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
-	"github.com/russellhaering/gosaml2"
-	"github.com/russellhaering/goxmldsig"
+	saml2 "github.com/mattermost/gosaml2"
+	dsig "github.com/russellhaering/goxmldsig"
 )
 
 var oktaScenarioErrors = map[int]string{

--- a/providertests/onelogin_test.go
+++ b/providertests/onelogin_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/russellhaering/gosaml2"
+	saml2 "github.com/mattermost/gosaml2"
 )
 
 var oneLoginScenarioErrors = map[int]string{

--- a/providertests/pingfed_test.go
+++ b/providertests/pingfed_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/russellhaering/gosaml2"
+	saml2 "github.com/mattermost/gosaml2"
 )
 
 var pingFedScenarioErrors = map[int]string{

--- a/providertests/providers_test.go
+++ b/providertests/providers_test.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
-	"github.com/russellhaering/gosaml2"
-	"github.com/russellhaering/goxmldsig"
+	saml2 "github.com/mattermost/gosaml2"
+	dsig "github.com/russellhaering/goxmldsig"
 )
 
 func TestValidateResponses(t *testing.T) {
@@ -94,7 +94,7 @@ func TestValidateResponses(t *testing.T) {
 				AudienceURI:                 "{audience}",
 				SkipSignatureValidation:     false,
 				AllowMissingAttributes:      true,
-				Clock: dsig.NewFakeClock(clockwork.NewFakeClockAt(time.Date(2017, 3, 8, 7, 51, 0, 0, time.UTC))),
+				Clock:                       dsig.NewFakeClock(clockwork.NewFakeClockAt(time.Date(2017, 3, 8, 7, 51, 0, 0, time.UTC))),
 			},
 		},
 		{
@@ -108,7 +108,7 @@ func TestValidateResponses(t *testing.T) {
 				AudienceURI:                 "JSAuth",
 				SkipSignatureValidation:     false,
 				AllowMissingAttributes:      true,
-				Clock: dsig.NewFakeClock(clockwork.NewFakeClockAt(time.Date(2016, 12, 12, 16, 55, 0, 0, time.UTC))),
+				Clock:                       dsig.NewFakeClock(clockwork.NewFakeClockAt(time.Date(2016, 12, 12, 16, 55, 0, 0, time.UTC))),
 			},
 		},
 	}

--- a/providertests/utils.go
+++ b/providertests/utils.go
@@ -13,9 +13,9 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
-	"github.com/russellhaering/gosaml2"
-	"github.com/russellhaering/gosaml2/types"
-	"github.com/russellhaering/goxmldsig"
+	saml2 "github.com/mattermost/gosaml2"
+	"github.com/mattermost/gosaml2/types"
+	dsig "github.com/russellhaering/goxmldsig"
 	"github.com/stretchr/testify/require"
 )
 

--- a/s2example/demo.go
+++ b/s2example/demo.go
@@ -10,8 +10,8 @@ import (
 	"encoding/base64"
 	"encoding/xml"
 
-	saml2 "github.com/russellhaering/gosaml2"
-	"github.com/russellhaering/gosaml2/types"
+	saml2 "github.com/mattermost/gosaml2"
+	"github.com/mattermost/gosaml2/types"
 	dsig "github.com/russellhaering/goxmldsig"
 )
 

--- a/saml.go
+++ b/saml.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/russellhaering/gosaml2/types"
+	"github.com/mattermost/gosaml2/types"
 	dsig "github.com/russellhaering/goxmldsig"
 	dsigtypes "github.com/russellhaering/goxmldsig/types"
 )
@@ -46,6 +46,8 @@ type SAMLServiceProvider struct {
 	ValidateEncryptionCert  bool
 	SkipSignatureValidation bool
 	AllowMissingAttributes  bool
+	ScopingIDPProviderId    string
+	ScopingIDPProviderName  string
 	Clock                   *dsig.Clock
 	signingContextMu        sync.RWMutex
 	signingContext          *dsig.SigningContext

--- a/saml_test.go
+++ b/saml_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 
 	"github.com/beevik/etree"
-	"github.com/russellhaering/gosaml2/types"
+	"github.com/mattermost/gosaml2/types"
 	dsig "github.com/russellhaering/goxmldsig"
 	"github.com/stretchr/testify/require"
 )

--- a/validate.go
+++ b/validate.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/russellhaering/gosaml2/types"
+	"github.com/mattermost/gosaml2/types"
 )
 
 //ErrParsing indicates that the value present in an assertion could not be


### PR DESCRIPTION
Summary -
Our current SAML implementation supports setting the scoping element. This PR implements the same functionality in the goSaml2 library we be using. 

https://github.com/mattermost/enterprise/blob/master/saml/service_provider.go#L88

Here is additional information about the feature for Azure.
https://techcommunity.microsoft.com/t5/Azure-Active-Directory-Identity/Using-Azure-AD-to-land-users-on-their-custom-login-page-from/ba-p/243900

Ticket Link

https://mattermost.atlassian.net/browse/MM-19864