### PR TITLE
MM-28108: Only add NameIdPolicy if NameIdFormat is set

### DIFF
--- a/build_request.go
+++ b/build_request.go
@@ -41,9 +41,11 @@ func (sp *SAMLServiceProvider) buildAuthnRequest(includeSig bool) (*etree.Docume
 		authnRequest.CreateElement("saml:Issuer").SetText(sp.IdentityProviderIssuer)
 	}
 
-	nameIdPolicy := authnRequest.CreateElement("samlp:NameIDPolicy")
-	nameIdPolicy.CreateAttr("AllowCreate", "true")
-	nameIdPolicy.CreateAttr("Format", sp.NameIdFormat)
+	if sp.NameIdFormat != "" {
+		nameIdPolicy := authnRequest.CreateElement("samlp:NameIDPolicy")
+		nameIdPolicy.CreateAttr("AllowCreate", "true")
+		nameIdPolicy.CreateAttr("Format", sp.NameIdFormat)
+	}
 
 	if sp.RequestedAuthnContext != nil {
 		requestedAuthnContext := authnRequest.CreateElement("samlp:RequestedAuthnContext")

--- a/build_request_test.go
+++ b/build_request_test.go
@@ -175,3 +175,48 @@ func TestScopingIDProviderOmitted(t *testing.T) {
 		require.Nil(t, el)
 	}
 }
+
+func TestScopingNameIDPolicyIncluded(t *testing.T) {
+	spURL := "https://sp.test"
+	sp := SAMLServiceProvider{
+		AssertionConsumerServiceURL: spURL,
+		AudienceURI:                 spURL,
+		IdentityProviderIssuer:      spURL,
+		IdentityProviderSSOURL:      "https://idp.test/saml/sso",
+		SignAuthnRequests:           false,
+		NameIdFormat:                NameIdFormatPersistent,
+	}
+
+	request, err := sp.BuildAuthRequest()
+	require.NoError(t, err)
+
+	doc := etree.NewDocument()
+	err = doc.ReadFromString(request)
+	require.NoError(t, err)
+
+	idpEntry := doc.FindElement("./AuthnRequest/NameIDPolicy")
+
+	require.Equal(t, idpEntry.SelectAttrValue("Format", ""), NameIdFormatPersistent)
+}
+
+func TestScopingNameIDPolicyOmitted(t *testing.T) {
+	spURL := "https://sp.test"
+
+	sp := SAMLServiceProvider{
+		AssertionConsumerServiceURL: spURL,
+		AudienceURI:                 spURL,
+		IdentityProviderIssuer:      spURL,
+		IdentityProviderSSOURL:      "https://idp.test/saml/sso",
+		SignAuthnRequests:           false,
+	}
+
+	request, err := sp.BuildAuthRequest()
+	require.NoError(t, err)
+
+	doc := etree.NewDocument()
+	err = doc.ReadFromString(request)
+	require.NoError(t, err)
+
+	el := doc.FindElement("./AuthnRequest/NameIDPolicy")
+	require.Nil(t, el)
+}


### PR DESCRIPTION
#### Summary
AuthnRequest element NameIDPolicy is optional. Only add it if the NameIdFormat is set. Adding without setting NameIdFormat has bee known to cause issues with some SAML Idp.

There is a PR for this in the upstream branch, however, unsure when it may be merged. Once this is merged, mattermost-server will need updated to this version. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28108
