### PR TITLE
Revert "Use AES instead of TripleDES cipher"

### DIFF
--- a/types/encrypted_key.go
+++ b/types/encrypted_key.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/des"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -173,10 +174,16 @@ func (ek *EncryptedKey) DecryptSymmetricKey(cert *tls.Certificate) (cipher.Block
 			//The RSA v1.5 Key Transport algorithm given below are those used in conjunction with TRIPLEDES
 			//Please also see https://www.w3.org/TR/xmlenc-core/#sec-Algorithms and
 			//https://www.w3.org/TR/xmlenc-core/#rsav15note.
-			b, err := aes.NewCipher(pt)
+			b, err := des.NewTripleDESCipher(pt)
 			if err != nil {
 				return nil, err
 			}
+
+			// FIXME: The version we had previously in our fork, AES seems more secure from my Googling.
+			// b, err := aes.NewCipher(pt)
+			// if err != nil {
+			// 	return nil, err
+			// }
 
 			return b, nil
 		default:


### PR DESCRIPTION
This reverts commit 70944041979a86a57c73708d24d4b80b759d14ea.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

