### PR TITLE
Configurable deflate-bomb protection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        go: ['1.17', '1.16']
+        go: ['1.24', '1.23', '1.22']
     steps:
       - uses: actions/checkout@v2
       - name: Setup Go

--- a/decode_logout_request.go
+++ b/decode_logout_request.go
@@ -49,7 +49,7 @@ func (sp *SAMLServiceProvider) ValidateEncodedLogoutRequestPOST(encodedRequest s
 	}
 
 	// Parse the raw request - parseResponse is generic
-	doc, el, err := parseResponse(raw)
+	doc, el, err := parseResponse(raw, sp.MaximumDecompressedBodySize)
 	if err != nil {
 		return nil, err
 	}

--- a/decode_response_test.go
+++ b/decode_response_test.go
@@ -224,5 +224,5 @@ func TestCompressionBombInput(t *testing.T) {
 	}
 
 	_, err = sp.RetrieveAssertionInfo(string(bs))
-	require.NoError(t, err, "Assertion info should be retrieved with no error")
+	require.Error(t, err, "error validating response: deflated response exceeds maximum size of 2048 bytes")
 }

--- a/saml.go
+++ b/saml.go
@@ -67,8 +67,14 @@ type SAMLServiceProvider struct {
 	ScopingIDPProviderId    string
 	ScopingIDPProviderName  string
 	Clock                   *dsig.Clock
-	signingContextMu        sync.RWMutex
-	signingContext          *dsig.SigningContext
+
+	// MaximumDecompressedBodySize is the maximum size to which a compressed
+	// SAML document will be decompressed. If a compresed document is exceeds
+	// this size during decompression an error will be returned.
+	MaximumDecompressedBodySize int64
+
+	signingContextMu sync.RWMutex
+	signingContext   *dsig.SigningContext
 }
 
 // RequestedAuthnContext controls which authentication mechanisms are requested of

--- a/saml_test.go
+++ b/saml_test.go
@@ -372,7 +372,7 @@ func TestSAMLCommentInjection(t *testing.T) {
 	*/
 
 	// To show that we are not vulnerable, we want to prove that we get the canonicalized value using our parser
-	_, el, err := parseResponse([]byte(commentInjectionAttackResponse))
+	_, el, err := parseResponse([]byte(commentInjectionAttackResponse), 0)
 	require.NoError(t, err)
 	decodedResponse := &types.Response{}
 	err = xmlUnmarshalElement(el, decodedResponse)


### PR DESCRIPTION
Importing upstream changes: https://github.com/russellhaering/gosaml2/commit/56f4c230beec96d3dfae709392a427802b4f47e1 and https://github.com/russellhaering/gosaml2/commit/629123cf78da94425d341ed99190cb68085841de