### PR TITLE
fix: validate ciphertext length before CBC/GCM decryption (Sentry W9)

### DIFF
--- a/saml_test.go
+++ b/saml_test.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"compress/flate"
 	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -27,9 +29,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/beevik/etree"
+	"github.com/jonboulle/clockwork"
 	"github.com/mattermost/gosaml2/types"
 	dsig "github.com/russellhaering/goxmldsig"
 	"github.com/stretchr/testify/require"
@@ -90,6 +95,37 @@ func TestDecode(t *testing.T) {
 	require.EqualValues(t, expected, assertion, "decrypted assertion did not match expectation")
 }
 
+// testKeyStoreAt implements dsig.X509KeyStore with a certificate valid at the
+// given time. This is needed because dsig.RandomKeyStoreForTest() generates
+// certs at time.Now(), which may not overlap with the idpCertificate's validity
+// window (expired 2026-02-09).
+type testKeyStoreAt struct {
+	key  *rsa.PrivateKey
+	cert []byte
+}
+
+func (ks *testKeyStoreAt) GetKeyPair() (*rsa.PrivateKey, []byte, error) {
+	return ks.key, ks.cert, nil
+}
+
+func keyStoreValidAt(t *testing.T, validAt time.Time) dsig.X509KeyStore {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             validAt.Add(-24 * time.Hour),
+		NotAfter:              validAt.Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return &testKeyStoreAt{key: key, cert: certDER}
+}
+
 func signResponse(t *testing.T, resp string, sp *SAMLServiceProvider) string {
 	doc := etree.NewDocument()
 	err := doc.ReadFromBytes([]byte(resp))
@@ -127,8 +163,19 @@ func TestSAML(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, cert)
 
-	randomKeyStore := dsig.RandomKeyStoreForTest()
-	_, _cert, err := randomKeyStore.GetKeyPair()
+	// Pin the clock to a time when the idpCertificate is still valid
+	// (cert valid: 2016-02-09 to 2026-02-09). We also create a test key
+	// store whose cert is valid at this pinned time, since
+	// dsig.RandomKeyStoreForTest() generates certs at time.Now() which
+	// may fall outside the idpCertificate's validity window.
+	//
+	// TODO: Replace idpCertificate with a long-lived test cert. See PR
+	// description for renewal instructions.
+	pinnedTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	fakeClock := dsig.NewFakeClock(clockwork.NewFakeClockAt(pinnedTime))
+
+	testKS := keyStoreValidAt(t, pinnedTime)
+	_, _cert, err := testKS.GetKeyPair()
 
 	cert0, err := x509.ParseCertificate(_cert)
 	require.NoError(t, err)
@@ -145,8 +192,9 @@ func TestSAML(t *testing.T) {
 		SignAuthnRequests:           true,
 		AudienceURI:                 "123",
 		IDPCertificateStore:         &certStore,
-		SPKeyStore:                  randomKeyStore,
+		SPKeyStore:                  testKS,
 		NameIdFormat:                NameIdFormatPersistent,
+		Clock:                       fakeClock,
 	}
 
 	authRequestURL, err := sp.BuildAuthURL("/some/link/here")

--- a/saml_test.go
+++ b/saml_test.go
@@ -176,6 +176,7 @@ func TestSAML(t *testing.T) {
 
 	testKS := keyStoreValidAt(t, pinnedTime)
 	_, _cert, err := testKS.GetKeyPair()
+	require.NoError(t, err)
 
 	cert0, err := x509.ParseCertificate(_cert)
 	require.NoError(t, err)

--- a/types/encrypted_assertion.go
+++ b/types/encrypted_assertion.go
@@ -56,6 +56,9 @@ func (ea *EncryptedAssertion) DecryptBytes(cert *tls.Certificate) ([]byte, error
 			return nil, fmt.Errorf("cannot create AES-GCM: %s", err)
 		}
 
+		if len(data) < c.NonceSize() {
+			return nil, fmt.Errorf("ciphertext too short for AES-GCM: got %d bytes, need at least %d for nonce", len(data), c.NonceSize())
+		}
 		nonce, data := data[:c.NonceSize()], data[c.NonceSize():]
 		plainText, err := c.Open(nil, nonce, data, nil)
 		if err != nil {
@@ -63,16 +66,38 @@ func (ea *EncryptedAssertion) DecryptBytes(cert *tls.Certificate) ([]byte, error
 		}
 		return plainText, nil
 	case MethodAES128CBC, MethodAES256CBC, MethodTripleDESCBC:
-		nonce, data := data[:k.BlockSize()], data[k.BlockSize():]
+		blockSize := k.BlockSize()
+
+		// The ciphertext must contain at least an IV (one block) plus one
+		// block of encrypted data, and the encrypted portion must be a
+		// multiple of the block size. Malformed or truncated SAML responses
+		// can violate these constraints, causing cipher.CryptBlocks to panic.
+		if len(data) < 2*blockSize {
+			return nil, fmt.Errorf("ciphertext too short for CBC decryption: got %d bytes, need at least %d", len(data), 2*blockSize)
+		}
+
+		nonce, data := data[:blockSize], data[blockSize:]
+		if len(data)%blockSize != 0 {
+			return nil, fmt.Errorf("ciphertext is not a multiple of the block size (%d): got %d bytes", blockSize, len(data))
+		}
+
 		c := cipher.NewCBCDecrypter(k, nonce)
 		c.CryptBlocks(data, data)
 
 		// Remove zero bytes
 		data = bytes.TrimRight(data, "\x00")
 
-		// Calculate index to remove based on padding
-		padLength := data[len(data)-1]
-		lastGoodIndex := len(data) - int(padLength)
+		if len(data) == 0 {
+			return nil, fmt.Errorf("decrypted CBC data is empty after trimming")
+		}
+
+		// Calculate index to remove based on PKCS#7 padding
+		padLength := int(data[len(data)-1])
+		if padLength == 0 || padLength > blockSize || padLength > len(data) {
+			return nil, fmt.Errorf("invalid PKCS#7 padding length: %d (block size %d, data length %d)", padLength, blockSize, len(data))
+		}
+
+		lastGoodIndex := len(data) - padLength
 		return data[:lastGoodIndex], nil
 	default:
 		return nil, fmt.Errorf("unknown symmetric encryption method %#v", ea.EncryptionMethod.Algorithm)

--- a/types/encrypted_assertion.go
+++ b/types/encrypted_assertion.go
@@ -68,17 +68,20 @@ func (ea *EncryptedAssertion) DecryptBytes(cert *tls.Certificate) ([]byte, error
 	case MethodAES128CBC, MethodAES256CBC, MethodTripleDESCBC:
 		blockSize := k.BlockSize()
 
-		// The ciphertext must contain at least an IV (one block) plus one
-		// block of encrypted data, and the encrypted portion must be a
-		// multiple of the block size. Malformed or truncated SAML responses
-		// can violate these constraints, causing cipher.CryptBlocks to panic.
+		// All validation and decryption errors in the CBC path return the
+		// same generic message to prevent padding oracle attacks. Distinct
+		// errors would let an attacker distinguish "invalid padding" from
+		// other failures, enabling block-by-block decryption of the
+		// ciphertext.
+		cbcErr := fmt.Errorf("failed to decrypt CBC ciphertext")
+
 		if len(data) < 2*blockSize {
-			return nil, fmt.Errorf("ciphertext too short for CBC decryption: got %d bytes, need at least %d", len(data), 2*blockSize)
+			return nil, cbcErr
 		}
 
 		nonce, data := data[:blockSize], data[blockSize:]
 		if len(data)%blockSize != 0 {
-			return nil, fmt.Errorf("ciphertext is not a multiple of the block size (%d): got %d bytes", blockSize, len(data))
+			return nil, cbcErr
 		}
 
 		c := cipher.NewCBCDecrypter(k, nonce)
@@ -88,13 +91,13 @@ func (ea *EncryptedAssertion) DecryptBytes(cert *tls.Certificate) ([]byte, error
 		data = bytes.TrimRight(data, "\x00")
 
 		if len(data) == 0 {
-			return nil, fmt.Errorf("decrypted CBC data is empty after trimming")
+			return nil, cbcErr
 		}
 
 		// Calculate index to remove based on PKCS#7 padding
 		padLength := int(data[len(data)-1])
 		if padLength == 0 || padLength > blockSize || padLength > len(data) {
-			return nil, fmt.Errorf("invalid PKCS#7 padding length: %d (block size %d, data length %d)", padLength, blockSize, len(data))
+			return nil, cbcErr
 		}
 
 		lastGoodIndex := len(data) - padLength

--- a/types/encrypted_assertion_test.go
+++ b/types/encrypted_assertion_test.go
@@ -88,17 +88,17 @@ func TestDecryptBytes_CBCTruncatedCiphertext(t *testing.T) {
 		{
 			name:        "empty ciphertext",
 			cipherData:  []byte{},
-			errContains: "ciphertext too short",
+			errContains: "failed to decrypt CBC ciphertext",
 		},
 		{
 			name:        "only IV, no data blocks",
 			cipherData:  make([]byte, 16), // exactly one block (IV only)
-			errContains: "ciphertext too short",
+			errContains: "failed to decrypt CBC ciphertext",
 		},
 		{
 			name:        "not a multiple of block size",
 			cipherData:  make([]byte, 16+17), // IV (16) + 17 bytes (> blockSize but not a multiple)
-			errContains: "not a multiple of the block size",
+			errContains: "failed to decrypt CBC ciphertext",
 		},
 	}
 

--- a/types/encrypted_assertion_test.go
+++ b/types/encrypted_assertion_test.go
@@ -1,0 +1,194 @@
+// Copyright 2016 Russell Haering et al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+)
+
+// generateTestCert creates a self-signed TLS certificate for testing.
+func generateTestCert(t *testing.T) *tls.Certificate {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	leaf, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	return &tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  key,
+		Leaf:        leaf,
+	}
+}
+
+// encryptSymmetricKey encrypts a symmetric key with RSA-OAEP using SHA-1
+// (matching the DecryptSymmetricKey implementation).
+func encryptSymmetricKey(t *testing.T, cert *tls.Certificate, symKey []byte) string {
+	t.Helper()
+	pubKey := cert.PrivateKey.(*rsa.PrivateKey).PublicKey
+	encKey, err := rsa.EncryptOAEP(sha1.New(), rand.Reader, &pubKey, symKey, nil)
+	if err != nil {
+		t.Fatalf("failed to encrypt symmetric key: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(encKey)
+}
+
+func TestDecryptBytes_CBCTruncatedCiphertext(t *testing.T) {
+	cert := generateTestCert(t)
+
+	symKey := make([]byte, 16) // AES-128
+	rand.Read(symKey)
+	encKeyB64 := encryptSymmetricKey(t, cert, symKey)
+
+	tests := []struct {
+		name        string
+		cipherData  []byte
+		errContains string
+	}{
+		{
+			name:        "empty ciphertext",
+			cipherData:  []byte{},
+			errContains: "ciphertext too short",
+		},
+		{
+			name:        "only IV, no data blocks",
+			cipherData:  make([]byte, 16), // exactly one block (IV only)
+			errContains: "ciphertext too short",
+		},
+		{
+			name:        "not a multiple of block size",
+			cipherData:  make([]byte, 16+17), // IV (16) + 17 bytes (> blockSize but not a multiple)
+			errContains: "not a multiple of the block size",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ea := &EncryptedAssertion{
+				EncryptionMethod: EncryptionMethod{
+					Algorithm: MethodAES128CBC,
+				},
+				EncryptedKey: EncryptedKey{
+					EncryptionMethod: EncryptionMethod{
+						Algorithm: MethodRSAOAEP,
+					},
+					CipherValue: encKeyB64,
+				},
+				CipherValue: base64.StdEncoding.EncodeToString(tt.cipherData),
+			}
+
+			_, err := ea.DecryptBytes(cert)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("expected error containing %q, got: %v", tt.errContains, err)
+			}
+		})
+	}
+}
+
+func TestDecryptBytes_GCMTruncatedCiphertext(t *testing.T) {
+	cert := generateTestCert(t)
+
+	symKey := make([]byte, 16)
+	rand.Read(symKey)
+	encKeyB64 := encryptSymmetricKey(t, cert, symKey)
+
+	// GCM nonce is 12 bytes — provide fewer bytes than that
+	ea := &EncryptedAssertion{
+		EncryptionMethod: EncryptionMethod{
+			Algorithm: MethodAES128GCM,
+		},
+		EncryptedKey: EncryptedKey{
+			EncryptionMethod: EncryptionMethod{
+				Algorithm: MethodRSAOAEP,
+			},
+			CipherValue: encKeyB64,
+		},
+		CipherValue: base64.StdEncoding.EncodeToString([]byte("short")),
+	}
+
+	_, err := ea.DecryptBytes(cert)
+	if err == nil {
+		t.Fatal("expected error for truncated GCM ciphertext, got nil")
+	}
+	if !strings.Contains(err.Error(), "too short for AES-GCM") {
+		t.Fatalf("expected 'too short for AES-GCM' error, got: %v", err)
+	}
+}
+
+// TestDecryptBytes_CBCInvalidPadding verifies that invalid PKCS#7 padding
+// returns an error instead of panicking or producing garbage.
+func TestDecryptBytes_CBCInvalidPadding(t *testing.T) {
+	cert := generateTestCert(t)
+
+	symKey := make([]byte, 16)
+	rand.Read(symKey)
+	encKeyB64 := encryptSymmetricKey(t, cert, symKey)
+
+	// Create ciphertext that will decrypt to data with invalid padding.
+	// IV (16 bytes) + one block (16 bytes) of zeros — after decryption,
+	// the last byte will likely be an invalid pad value.
+	cipherData := make([]byte, 32)
+	rand.Read(cipherData) // random data won't have valid PKCS#7 padding
+
+	ea := &EncryptedAssertion{
+		EncryptionMethod: EncryptionMethod{
+			Algorithm: MethodAES128CBC,
+		},
+		EncryptedKey: EncryptedKey{
+			EncryptionMethod: EncryptionMethod{
+				Algorithm: MethodRSAOAEP,
+			},
+			CipherValue: encKeyB64,
+		},
+		CipherValue: base64.StdEncoding.EncodeToString(cipherData),
+	}
+
+	// This should either return an error or return data without panicking.
+	// Before the fix, certain inputs would cause an index-out-of-range panic.
+	_, err := ea.DecryptBytes(cert)
+	// We accept either an error or success — the key requirement is no panic.
+	_ = err
+}


### PR DESCRIPTION
## Summary

**Sentry:** [W9 — SAML login crash](https://mattermost-mr.sentry.io/issues/7286219464/) · 11 crashes · 1 affected instance (`anselm-mm.devproxy.linotp.de`) · first seen 2026-02-23

A malformed encrypted SAML assertion causes `crypto/cipher.CBCDecrypter.CryptBlocks` to panic with `input not full blocks`, crashing the server process. Every SAML login attempt from the affected IdP triggers the crash — users cannot log in and the server must be restarted.

---

## Changes

### 1. Input validation for DecryptBytes

Add bounds checks before calling `CryptBlocks`/`GCM.Open` so malformed ciphertext returns a descriptive error instead of panicking.

#### When does this happen?

- **Truncated HTTP response** — reverse proxy, WAF, or load balancer cuts the SAML response (AWS ALB body limits, nginx `client_max_body_size`, proxy timeouts)
- **Malformed IdP response** — non-standard or misconfigured IdP emits incorrect `CipherValue` (algorithm mismatch, key size confusion, broken XML encryption)
- **Base64/encoding corruption** — character re-encoding in transit, `+` chars URL-encoded inconsistently in SAML POST binding
- **Adversarial input** — crafted SAML response probing the SP; a panic = denial of service

#### Validations added

| Mode | Check | Why |
|------|-------|-----|
| CBC | `len(data) >= 2*blockSize` | Need at least IV + one encrypted block |
| CBC | `len(data) % blockSize == 0` | `CryptBlocks` panics otherwise |
| CBC | PKCS#7 pad byte `0 < pad <= blockSize` | Prevents out-of-bounds slice on garbage padding |
| CBC | Post-trim data non-empty | Catches all-zero-byte decryption results |
| GCM | `len(data) >= nonceSize` | Need at least the 12-byte nonce before calling `Open` |

### 2. Fix expired test certificate (clock pinning)

The `idpCertificate` in `test_constants.go` expired **2026-02-09**, silently breaking `TestSAML`. The last CI run on `master` was **2025-06-02** — before the expiry. No commits since = no CI runs = undetected failure.

**Fix:** Pin the test clock to `2025-01-01` (within the cert's validity window) and use a custom key store whose certificate is also valid at the pinned time.

---

## ⚠️ Follow-up: Certificate Renewal

The clock-pinning is a **workaround**. The proper fix is to regenerate the test certificate with a longer validity period.

### Steps

1. **Generate a new test cert** (valid 100 years):
```bash
openssl req -x509 -newkey rsa:2048 -keyout /dev/null -nodes \
  -out idp_test_cert.pem -days 36500 \
  -subj "/C=US/ST=California/L=San Francisco/O=Okta/OU=SSOProvider/CN=dev-116807/emailAddress=info@okta.com"
```

2. **Replace `idpCertificate`** in `test_constants.go` with the new PEM.

3. **Audit tamper-detection tests** — `manInTheMiddledResponse` and similar embed the old cert's signature. Most tests re-sign at runtime so they'll work, but tamper tests may need their embedded `X509Certificate` elements updated.

4. **Regenerate `testdata/test.crt` + `testdata/test.key`** (also expired, May 2016) and re-encrypt `testdata/saml.post`:
```bash
openssl req -x509 -newkey rsa:2048 -keyout testdata/test.key -nodes \
  -out testdata/test.crt -days 36500 -subj "/CN=test"
```

5. **Remove the clock-pinning workaround** from `saml_test.go` and revert to `dsig.RandomKeyStoreForTest()`.

### Complexity estimate
- Cert generation + replacement: **~10 min**
- Audit tamper-detection tests + re-encrypt test data: **30-60 min**
- Total: **~1 hour**

---

## Release Note

Fixed a server crash when processing malformed or truncated encrypted SAML assertions during login.


Co-authored-by: Claude <claude@anthropic.com>

#### Release Note
```release-note
Fixed a panic in SAML response decryption when the server receives a malformed or truncated ciphertext (Sentry W9).
```